### PR TITLE
build: improve and correct GitHub actions

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -15,7 +15,7 @@ jobs:
         # We should build a binary executable for windows-2016,
         # But currently, the oldest available version is windows-2019.
         # We also build a binary executable for ubuntu-20.04 for integration tests.
-        os: [windows-2019, ubuntu-20.04]
+        os: [ windows-2019, ubuntu-20.04 ]
 
     steps:
       - name: Checkout github repo (+ download lfs dependencies)

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,19 +15,19 @@ jobs:
       matrix:
         # We should build a binary executable for windows-2016,
         # But currently, the oldest available version is windows-2019.
-        os: [windows-2019, ubuntu-20.04]
-        python-version: ["3.8", "3.9"]
+        os: [ windows-2019, ubuntu-20.04 ]
+        python-version: [ "3.8", "3.9" ]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .[test]
-    - name: Test with pytest
-      run: |
-        pytest
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[test]
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: Test Python 🐍 package 📦
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ '**' ]
 
 jobs:
   build:
@@ -16,7 +16,7 @@ jobs:
         # We should build a binary executable for windows-2016,
         # But currently, the oldest available version is windows-2019.
         os: [ windows-2019, ubuntu-20.04 ]
-        python-version: [ "3.8", "3.9" ]
+        python-version: [ '3.8', '3.9' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -10,7 +10,7 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 permissions:
   contents: read
@@ -21,21 +21,21 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install build
-    - name: Build Python 🐍 packages
-      run: python -m build
-    - name: Publish distribution 📦 to PyPI
-      # Upload packages only on a tagged commit
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+      - name: Build Python 🐍 packages
+        run: python -m build
+      - name: Publish distribution 📦 to PyPI
+        # Upload packages only on a tagged commit
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.x'
+          python-version: '3.8'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -34,7 +34,7 @@ jobs:
         run: python -m build
       - name: Publish distribution 📦 to PyPI
         # Upload packages only on a tagged commit
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
The `on.release.published` action doesn't work yet.

This PR change the filter in "Publish distribution 📦 to PyPI" to publish on tag creation only (don't filter on event name).