### PR TITLE
build: prepare next minor release v1.3.0 (unreleased)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.2.1] - (unreleased)
+## [1.3.0] - (unreleased)
 
 ## [1.2.0] - 2023-02-21
 
@@ -63,7 +63,7 @@
 - Remove unnecessary Optional
 - Enable ssh_config_file to be `None`
 
-[1.2.1]: https://github.com/AntaresSimulatorTeam/antares-launcher/compare/v1.2.0...HEAD
+[1.3.0]: https://github.com/AntaresSimulatorTeam/antares-launcher/compare/v1.2.0...HEAD
 
 [1.2.0]: https://github.com/AntaresSimulatorTeam/antares-launcher/releases/tag/v1.2.0
 

--- a/antareslauncher/__init__.py
+++ b/antareslauncher/__init__.py
@@ -9,9 +9,9 @@ This module contains the project metadata.
 
 # Standard project metadata
 
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 __author__ = "RTE, Antares Web Team"
-__date__ = "2023-02-21"
+__date__ = "(unreleased)"
 # noinspection SpellCheckingInspection
 __credits__ = "(c) Réseau de Transport de l’Électricité (RTE)"
 


### PR DESCRIPTION
The version number on the `dev` branch must be a minor (or major) version number, but not a patch version number.