### PR TITLE
fix: correct download progress bar in logs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.3] - unreleased
+
+### Fixes
+
 ## [1.2.2] - 2023-03-02
 
 ### Fixes
@@ -73,6 +77,8 @@
 - Add proper output for `study_list_composer.py`
 - Remove unnecessary Optional
 - Enable ssh_config_file to be `None`
+
+[1.2.3]: https://github.com/AntaresSimulatorTeam/antares-launcher/compare/v1.2.2...HEAD
 
 [1.2.2]: https://github.com/AntaresSimulatorTeam/antares-launcher/releases/tag/v1.2.2
 

--- a/antareslauncher/__init__.py
+++ b/antareslauncher/__init__.py
@@ -9,9 +9,9 @@ This module contains the project metadata.
 
 # Standard project metadata
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 __author__ = "RTE, Antares Web Team"
-__date__ = "2023-03-02"
+__date__ = "unreleased"
 # noinspection SpellCheckingInspection
 __credits__ = "(c) Réseau de Transport de l’Électricité (RTE)"
 

--- a/antareslauncher/remote_environnement/ssh_connection.py
+++ b/antareslauncher/remote_environnement/ssh_connection.py
@@ -55,29 +55,29 @@ class DownloadMonitor:
         self.msg = msg or "Downloading..."
         self.logger = logger or logging.getLogger(__name__)
         self._start_time = time.time()
-        self._size = 0
+        self._transferred = 0
         self._progress: int = 0
 
     def __call__(self, transferred: int, subtotal: int) -> None:
         if not self.total_size:
             return
-        self._size += transferred
+        self._transferred = transferred
         # Avoid emitting too many messages
-        rate = self._size / self.total_size
+        rate = self._transferred / self.total_size
         if self._progress != int(rate * 10):
             self._progress = int(rate * 10)
             self.logger.info(str(self))
 
     def __str__(self):
-        rate = self._size / self.total_size
-        if self._size:
+        rate = self._transferred / self.total_size
+        if self._transferred:
             # Calculate ETA and progress rate
             # 0        curr_size                   total_size
             # |----------->|--------------------------->|
             # 0        duration                    total_duration
             # 0%       percent                         100%
             duration = time.time() - self._start_time
-            eta = int(duration * (self.total_size - self._size) / self._size)
+            eta = int(duration * (self.total_size - self._transferred) / self._transferred)
             return f"{self.msg:<20} ETA: {eta}s [{rate:.0%}]"
         return f"{self.msg:<20} ETA: ??? [{rate:.0%}]"
 

--- a/tests/unit/test_ssh_connection.py
+++ b/tests/unit/test_ssh_connection.py
@@ -30,8 +30,8 @@ class TestDownloadMinotor:
         total_size = 1000
         monitor = DownloadMonitor(total_size, msg="Downloading 'foo'")
         with caplog.at_level(level=logging.INFO, logger=LOGGER):
-            for _ in range(0, total_size, 250):
-                monitor(250, 0)
+            for transferred in range(250, total_size + 1, 250):
+                monitor(transferred, 0)
                 time.sleep(0.01)
         assert caplog.messages == [
             "Downloading 'foo'    ETA: 0s [25%]",


### PR DESCRIPTION
L'objectif de cett PR est de corriger l'affichage de la barre de progression qui s'affiche dans les logs lorsqu'on télécharge des fichiers depuis la connection SSH.

Le calcul du pourcentage est faux car la quantité transférée (donnée par le paramètre `transferred`) correspond à un cumul d'octet et non pas à la quantité à un instant _t_.

Cette PR ajoute aussi la documentation manquante de la classe [`DownloadMonitor`](https://github.com/AntaresSimulatorTeam/antares-launcher/blob/7041c076f3e186546cfc50eb8ce3c6ae41458cd8/antareslauncher/remote_environnement/ssh_connection.py#L51).