### PR TITLE
test: remove output exclusion to allow xpansion sensitivity

### DIFF
--- a/antareslauncher/use_cases/launch/study_zipper.py
+++ b/antareslauncher/use_cases/launch/study_zipper.py
@@ -23,7 +23,7 @@ class StudyZipper:
         return self._current_study
 
     def _do_zip(self):
-        zipfile_path = self._current_study.path + "-" + getpass.getuser() + ".zip"
+        zipfile_path = f"{self._current_study.path}-{getpass.getuser()}.zip"
         success = self.file_manager.zip_dir_excluding_subdir(
             self._current_study.path, zipfile_path, None
         )
@@ -36,11 +36,11 @@ class StudyZipper:
     def _display_failure_error(self):
         self.display.show_error(
             f'"{Path(self._current_study.path).name}": was not zipped',
-            __name__ + "." + __class__.__name__,
+            f"{__name__}.{__class__.__name__}",
         )
 
     def _display_success_message(self):
         self.display.show_message(
             f'"{Path(self._current_study.path).name}": was zipped',
-            __name__ + "." + __class__.__name__,
+            f"{__name__}.{__class__.__name__}",
         )

--- a/tests/unit/launcher/test_launch_controller.py
+++ b/tests/unit/launcher/test_launch_controller.py
@@ -103,9 +103,9 @@ class TestLauncherController:
         )
         my_launcher.launch_all_studies()
 
-        zipfile_path = my_study.path + "-" + getpass.getuser() + ".zip"
+        zipfile_path = f"{my_study.path}-{getpass.getuser()}.zip"
         file_manager.zip_dir_excluding_subdir.assert_called_once_with(
-            my_study.path, zipfile_path, "output"
+            my_study.path, zipfile_path, None
         )
 
     @pytest.mark.unit_test
@@ -119,9 +119,7 @@ class TestLauncherController:
         my_launcher.repo.save_study = mock.Mock()
         my_launcher.launch_all_studies()
         # then
-        expected_study.zipfile_path = (
-            expected_study.path + "-" + getpass.getuser() + ".zip"
-        )
+        expected_study.zipfile_path = f"{expected_study.path}-{getpass.getuser()}.zip"
         second_call = my_launcher.repo.save_study.call_args_list[1]
         first_argument = second_call[0][0]
         assert first_argument.zip_is_sent

--- a/tests/unit/launcher/test_zipper.py
+++ b/tests/unit/launcher/test_zipper.py
@@ -22,7 +22,7 @@ class TestStudyZipper:
 
         self.study_zipper.zip(study)
 
-        expected_message = f'"hello": was zipped'
+        expected_message = '"hello": was zipped'
         self.display_mock.show_message.assert_called_once_with(
             expected_message, mock.ANY
         )
@@ -34,7 +34,7 @@ class TestStudyZipper:
 
         new_study = self.study_zipper.zip(study)
 
-        expected_message = f'"hello": was not zipped'
+        expected_message = '"hello": was not zipped'
         self.display_mock.show_error.assert_called_once_with(expected_message, mock.ANY)
         assert new_study.zipfile_path == ""
 
@@ -60,8 +60,8 @@ class TestStudyZipper:
 
         new_study = self.study_zipper.zip(study)
 
-        expected_zipfile_path = study.path + "-" + getpass.getuser() + ".zip"
+        expected_zipfile_path = f"{study.path}-{getpass.getuser()}.zip"
         self.file_manager.zip_dir_excluding_subdir.assert_called_once_with(
-            study_path, expected_zipfile_path, "output"
+            study_path, expected_zipfile_path, None
         )
         assert new_study.zipfile_path == expected_zipfile_path


### PR DESCRIPTION
Follows the last PR i merged without checking the UTs (https://github.com/AntaresSimulatorTeam/antares-launcher/pull/46) ... So this PR contains the associated UTs