### PR TITLE
fix(job-state): consider the `COMPLETING` value as a possible job state

### DIFF
--- a/antareslauncher/remote_environnement/remote_environment_with_slurm.py
+++ b/antareslauncher/remote_environnement/remote_environment_with_slurm.py
@@ -84,6 +84,9 @@ class JobStateCodes(enum.Enum):
     # Job has terminated all processes on all nodes with an exit code of zero.
     COMPLETED = "COMPLETED"
 
+    # Indicates that the only job on the node or that all jobs on the node are in the process of completing.
+    COMPETING = "COMPLETING"
+
     # Job terminated on deadline.
     DEADLINE = "DEADLINE"
 
@@ -288,6 +291,7 @@ class RemoteEnvironmentWithSlurm:
             JobStateCodes.BOOT_FAIL: (False, False, False),
             JobStateCodes.CANCELLED: (True, True, True),
             JobStateCodes.COMPLETED: (True, True, False),
+            JobStateCodes.COMPETING: (True, False, False),
             JobStateCodes.DEADLINE: (True, True, True),  # similar to timeout
             JobStateCodes.FAILED: (True, True, True),
             JobStateCodes.NODE_FAIL: (True, True, True),

--- a/tests/unit/retriever/test_study_retriever.py
+++ b/tests/unit/retriever/test_study_retriever.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+
 from antareslauncher.data_repo.data_reporter import DataReporter
 from antareslauncher.data_repo.idata_repo import IDataRepo
 from antareslauncher.display.idisplay import IDisplay

--- a/tests/unit/test_remote_environment_with_slurm.py
+++ b/tests/unit/test_remote_environment_with_slurm.py
@@ -376,6 +376,7 @@ class TestRemoteEnvironmentWithSlurm:
             call(command),
         ]
 
+    # noinspection SpellCheckingInspection
     @pytest.mark.unit_test
     @pytest.mark.parametrize(
         "state, expected",
@@ -387,6 +388,7 @@ class TestRemoteEnvironmentWithSlurm:
             ("CANCELLED by 123456", (True, True, True)),
             ("TIMEOUT", (True, True, True)),
             ("COMPLETED", (True, True, False)),
+            ("COMPLETING", (True, False, False)),
             ("FAILED", (True, True, True)),
         ],
     )


### PR DESCRIPTION
This correction allows for considering the `COMPLETING` value as a possible state of a job. This value is returned by the `scontrol` command.