### PR TITLE
fix(retriever): avoid infinite loop if `sbatch` command fails

### DIFF
--- a/antareslauncher/use_cases/retrieve/state_updater.py
+++ b/antareslauncher/use_cases/retrieve/state_updater.py
@@ -39,7 +39,7 @@ class StateUpdater:
         Args:
             study: The study data transfer object
         """
-        if not study.done:
+        if not study.done and not study.with_error:
             # set current study job state flags
             if study.job_id:
                 s, f, e = self._env.get_job_state_flags(study)

--- a/tests/unit/retriever/test_study_retriever.py
+++ b/tests/unit/retriever/test_study_retriever.py
@@ -55,6 +55,15 @@ class TestStudyRetriever:
         self.zip_extractor.extract_final_zip.assert_not_called()
 
     @pytest.mark.unit_test
+    def test_given_study_with_error_study_is_still_in_error(self):
+        env = mock.Mock()
+        display = mock.Mock()
+        self.state_updater = StateUpdater(env=env, display=display)
+        study_with_error = StudyDTO(path="hello", with_error=True)
+        self.study_retriever.retrieve(study_with_error)
+        assert study_with_error.with_error
+
+    @pytest.mark.unit_test
     def test_retrieve_study(self):
         """
         This test function simulates the retrieval process of a study and verifies


### PR DESCRIPTION
I've tested on my local env and it works.