### PR TITLE
build(deps): bump paramiko version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bcrypt~=3.2.2
 cffi~=1.15.1
 cryptography~=39.0.1
-paramiko~=2.12.0
+paramiko~=3.4.1
 pycparser~=2.21
 PyNaCl~=1.5.0
 PyYAML~=5.4.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from antareslauncher import __author__, __project_name__, __version__
 # detect incompatibility problems.
 # Warning: this package is used as a library, so you should not constrain the versions too much.
 install_requires = [
-    "paramiko < 3.0",  # version 3.0.0 is not mature yet (2023-01-22)
+    "paramiko~= 3.4.1",
     "PyYAML < 6.0",  # required version for AntaREST
     "tinydb < 4.8",
     "tqdm < 4.65",


### PR DESCRIPTION
Use newest paramiko version to remove irritating warning inside AntaREST and to fix potential security breach (fixed in paramiko 3.4.0)