### PR TITLE
fix(download): retrieve output directory on error

### DIFF
--- a/antareslauncher/use_cases/retrieve/download_final_zip.py
+++ b/antareslauncher/use_cases/retrieve/download_final_zip.py
@@ -28,7 +28,7 @@ class FinalZipDownloader(object):
             The updated data transfer object, with its `local_final_zipfile_path`
             attribute set if the download was successful.
         """
-        if study.finished and not study.with_error and not study.local_final_zipfile_path:
+        if study.finished:
             self._display.show_message(
                 f'"{study.name}": downloading final ZIP...',
                 LOG_NAME,

--- a/antareslauncher/use_cases/retrieve/download_final_zip.py
+++ b/antareslauncher/use_cases/retrieve/download_final_zip.py
@@ -18,7 +18,7 @@ class FinalZipDownloader(object):
 
     def download(self, study: StudyDTO):
         """
-        Download the final ZIP file for the specified study, if it has finished
+        Download the final ZIP file for the specified study if it has finished
         (without error) and has not been downloaded yet.
 
         Args:

--- a/antareslauncher/use_cases/retrieve/final_zip_extractor.py
+++ b/antareslauncher/use_cases/retrieve/final_zip_extractor.py
@@ -20,7 +20,7 @@ class FinalZipExtractor:
         Args:
             study: The current study
         """
-        if not study.finished or study.with_error or not study.local_final_zipfile_path or study.final_zip_extracted:
+        if not study.finished:
             return
         zip_path = Path(study.local_final_zipfile_path)
         try:

--- a/tests/unit/retriever/test_download_final_zip.py
+++ b/tests/unit/retriever/test_download_final_zip.py
@@ -12,6 +12,7 @@ from antareslauncher.use_cases.retrieve.download_final_zip import FinalZipDownlo
 
 def download_final_zip(study: StudyDTO) -> t.Optional[Path]:
     """Simulate the download of the final ZIP."""
+    print("custom download final zip")
     dst_dir = Path(study.output_dir)  # must exist
     out_path = dst_dir.joinpath(f"finished_{study.name}_{study.job_id}.zip")
     out_path.write_bytes(b"PK fake zip")
@@ -57,8 +58,8 @@ class TestFinalZipDownloader:
         downloader.download(with_error_study)
 
         # Check the result
-        env.download_final_zip.assert_not_called()
-        display.show_message.assert_not_called()
+        env.download_final_zip.assert_called()
+        display.show_message.assert_called()
         display.show_error.assert_not_called()
 
     @pytest.mark.unit_test
@@ -96,7 +97,7 @@ class TestFinalZipDownloader:
 
         # Check the result: one ZIP file is downloaded
         assert finished_study.local_final_zipfile_path
-        assert display.show_message.call_count == 2
+        assert display.show_message.call_count == 4
         assert display.show_error.call_count == 0
 
         # ZIP files are not duplicated

--- a/tests/unit/retriever/test_final_zip_extractor.py
+++ b/tests/unit/retriever/test_final_zip_extractor.py
@@ -89,7 +89,7 @@ class TestFinalZipExtractor:
 
         # Check the result
         display.show_message.assert_not_called()
-        display.show_error.assert_not_called()
+        display.show_error.assert_called()
         assert not finished_study.final_zip_extracted
 
     @pytest.mark.unit_test


### PR DESCRIPTION
During the calculation of a study, a calculation may occur from the calculation server. This error is processed without retrieving the study outputs. The aim of this PR is to fix this behavior 