### PR TITLE
fix(xpansion): remove check on candidates

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
         # We should build a binary executable for windows-2016,
         # But currently, the oldest available version is windows-2022.
         os: [ windows-2022, ubuntu-22.04 ]
-        python-version: [ '3.10', '3.11', '3.12']
+        python-version: [ '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
         # We should build a binary executable for windows-2016,
         # But currently, the oldest available version is windows-2022.
         os: [ windows-2022, ubuntu-22.04 ]
-        python-version: [ '3.11', '3.12', '3.13', '3.14']
+        python-version: [ '3.11', '3.12', '3.13' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
         # We should build a binary executable for windows-2016,
         # But currently, the oldest available version is windows-2022.
         os: [ windows-2022, ubuntu-22.04 ]
-        python-version: [ '3.11', '3.12' ]
+        python-version: [ '3.11', '3.12', '3.13', '3.14' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
         # We should build a binary executable for windows-2016,
         # But currently, the oldest available version is windows-2022.
         os: [ windows-2022, ubuntu-22.04 ]
-        python-version: [ '3.11', '3.12', '3.13' ]
+        python-version: [ '3.11', '3.12' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The main workflow diagram is as follows:
 
 See [`setup.py`](https://github.com/AntaresSimulatorTeam/antares-launcher/blob/main/setup.py)
 
-Minimum version : python 3.10
+Minimum version : python 3.11
 
 ### Main Python libraries
 

--- a/antareslauncher/enums.py
+++ b/antareslauncher/enums.py
@@ -1,0 +1,27 @@
+from enum import IntEnum, StrEnum
+
+
+class Modes(IntEnum):
+    antares = 1
+    xpansion_r = 2
+    xpansion_cpp = 3
+    xpansion_trajectory = 4
+
+
+class XpansionMode(StrEnum):
+    NOT_XPANSION = ""
+    R = "r"
+    CPP = "cpp"
+    TRAJECTORY = "trajectory"
+
+    def to_run_mode(self) -> Modes:
+        if self == XpansionMode.NOT_XPANSION:
+            return Modes.antares
+        elif self == XpansionMode.R:
+            return Modes.xpansion_r
+        elif self == XpansionMode.CPP:
+            return Modes.xpansion_cpp
+        elif self == XpansionMode.TRAJECTORY:
+            return Modes.xpansion_trajectory
+        else:
+            raise ValueError(f"Unknown Xpansion mode: {self}")

--- a/antareslauncher/remote_environnement/slurm_script_features.py
+++ b/antareslauncher/remote_environnement/slurm_script_features.py
@@ -3,7 +3,7 @@ import shlex
 
 from antares.study.version import SolverMinorVersion
 
-from antareslauncher.study_dto import Modes
+from antareslauncher.enums import Modes
 
 
 @dataclasses.dataclass

--- a/antareslauncher/study_dto.py
+++ b/antareslauncher/study_dto.py
@@ -1,17 +1,11 @@
 import typing as t
 
 from dataclasses import dataclass, field
-from enum import IntEnum
 from pathlib import Path
 
 from antares.study.version import StudyVersion
 
-
-class Modes(IntEnum):
-    antares = 1
-    xpansion_r = 2
-    xpansion_cpp = 3
-    xpansion_trajectory = 4
+from antareslauncher.enums import Modes, XpansionMode
 
 
 @dataclass
@@ -48,7 +42,7 @@ class StudyDTO:
     time_limit: t.Optional[int] = None
     n_cpu: int = 1
     antares_version: StudyVersion = StudyVersion.parse(0)
-    xpansion_mode: str = ""  # "", "r", "cpp", "trajectory"
+    xpansion_mode: XpansionMode = XpansionMode.NOT_XPANSION
     run_mode: Modes = Modes.antares
     post_processing: bool = False
     other_options: str = ""

--- a/antareslauncher/use_cases/create_list/study_list_composer.py
+++ b/antareslauncher/use_cases/create_list/study_list_composer.py
@@ -8,7 +8,8 @@ from antares.study.version import SolverMinorVersion, StudyVersion
 
 from antareslauncher.data_repo.data_repo_tinydb import DataRepoTinydb
 from antareslauncher.display.display_terminal import DisplayTerminal
-from antareslauncher.study_dto import Modes, StudyDTO
+from antareslauncher.enums import XpansionMode
+from antareslauncher.study_dto import StudyDTO
 
 DEFAULT_VERSION = SolverMinorVersion.parse(0)
 
@@ -53,7 +54,7 @@ class StudyListComposerParameters:
     time_limit: int
     log_dir: str
     n_cpu: int
-    xpansion_mode: str  # "", "r", "cpp", "trajectory"
+    xpansion_mode: XpansionMode
     output_dir: str
     post_processing: bool
     antares_versions_on_remote_server: t.Sequence[SolverMinorVersion]
@@ -95,13 +96,7 @@ class StudyListComposer:
         """
         return self._repo.get_list_of_studies()
 
-    def _create_study(self, path: Path, antares_version: SolverMinorVersion, xpansion_mode: str) -> StudyDTO:
-        run_mode = {
-            "": Modes.antares,
-            "r": Modes.xpansion_r,
-            "cpp": Modes.xpansion_cpp,
-            "trajectory": Modes.xpansion_trajectory,
-        }.get(xpansion_mode, Modes.antares)
+    def _create_study(self, path: Path, antares_version: SolverMinorVersion, xpansion_mode: XpansionMode) -> StudyDTO:
         new_study = StudyDTO(
             path=str(path),
             n_cpu=self.n_cpu,
@@ -110,7 +105,7 @@ class StudyListComposer:
             job_log_dir=self.DEFAULT_JOB_LOG_DIR_PATH,
             output_dir=str(self.output_dir),
             xpansion_mode=xpansion_mode,
-            run_mode=run_mode,
+            run_mode=xpansion_mode.to_run_mode(),
             post_processing=self.post_processing,
             other_options=self.other_options,
             oversubscribe=self._oversubscribe,
@@ -135,7 +130,7 @@ class StudyListComposer:
                 if (directory_path / "input-trajectory.yaml").exists():
                     # Means this is an Xpansion trajectory study.
                     solver_version = _find_study_version_for_xpansion_trajectory(directory_path)
-                    xpansion_mode = "trajectory"
+                    xpansion_mode = XpansionMode.TRAJECTORY
                 else:
                     # Usual behavior, the directory_path should contain a `study.antares` file.
                     solver_version = get_solver_version(directory_path)
@@ -146,7 +141,7 @@ class StudyListComposer:
             self._display.show_message("Didn't find any new simulations...", f"{__name__}.{self.__class__.__name__}")
 
     def _update_database_with_directory(
-        self, directory_path: Path, solver_version: SolverMinorVersion, xpansion_mode: str
+        self, directory_path: Path, solver_version: SolverMinorVersion, xpansion_mode: XpansionMode
     ) -> None:
         antares_version = self.antares_version if self.antares_version != DEFAULT_VERSION else solver_version
         if not antares_version:
@@ -158,13 +153,9 @@ class StudyListComposer:
             )
             self._display.show_message(message, __name__ + "." + self.__class__.__name__)
         else:
-            valid_xpansion_candidate = self.xpansion_mode in {"r", "cpp", "trajectory"}
-            valid_antares_candidate = not self.xpansion_mode
-
-            if valid_antares_candidate or valid_xpansion_candidate:
-                buffer_study = self._create_study(directory_path, antares_version, xpansion_mode)
-                if not self._repo.is_study_inside_database(buffer_study):
-                    self._add_study_to_database(buffer_study)
+            buffer_study = self._create_study(directory_path, antares_version, xpansion_mode)
+            if not self._repo.is_study_inside_database(buffer_study):
+                self._add_study_to_database(buffer_study)
 
     def _add_study_to_database(self, buffer_study: StudyDTO) -> None:
         self._repo.save_study(buffer_study)

--- a/antareslauncher/use_cases/create_list/study_list_composer.py
+++ b/antareslauncher/use_cases/create_list/study_list_composer.py
@@ -139,22 +139,11 @@ class StudyListComposer:
                 else:
                     # Usual behavior, the directory_path should contain a `study.antares` file.
                     solver_version = get_solver_version(directory_path)
-                    xpansion_mode = self._get_xpansion_mode(directory_path)
+                    xpansion_mode = self.xpansion_mode
                 self._update_database_with_directory(directory_path, solver_version, xpansion_mode)
 
         if not self._new_study_added:
             self._display.show_message("Didn't find any new simulations...", f"{__name__}.{self.__class__.__name__}")
-
-    def _get_xpansion_mode(self, study_path: Path) -> str:
-        """
-        Checks if the given study contains Xpansion candidates.
-        If it does, return self.xpansion_mode.
-        Else, return an empty string. This way when comparing self.xpansion_mode and the empty string we can detect
-        if there are inconsistencies between the study and what the user asked for.
-        """
-        candidates_file_path = study_path.joinpath("user", "expansion", "candidates.ini")
-        is_xpansion_study = candidates_file_path.is_file()
-        return self.xpansion_mode if is_xpansion_study else ""
 
     def _update_database_with_directory(
         self, directory_path: Path, solver_version: SolverMinorVersion, xpansion_mode: str
@@ -169,7 +158,7 @@ class StudyListComposer:
             )
             self._display.show_message(message, __name__ + "." + self.__class__.__name__)
         else:
-            valid_xpansion_candidate = self.xpansion_mode == xpansion_mode
+            valid_xpansion_candidate = self.xpansion_mode in {"r", "cpp", "trajectory"}
             valid_antares_candidate = not self.xpansion_mode
 
             if valid_antares_candidate or valid_xpansion_candidate:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ["py38"]
+target-version = ["py311"]
 line-length = 120
 exclude = "(data/*|docs/*|remote_scripts_templates/*|target/*)"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,13 @@
 -r requirements.txt
 
 attrs==22.2.0
-coverage==7.1.0
+coverage~=7.15.2
 exceptiongroup==1.1.0
-execnet==1.9.0
+execnet~=2.1.2
 iniconfig==2.0.0
 packaging==23.0
-pluggy==1.0.0
-pytest==7.2.1
-pytest-cov==4.0.0
-pytest-xdist==3.1.0
+pluggy~=1.6.0
+pytest~=9.1.1
+pytest-cov~=7.1.0
+pytest-xdist~=3.8.0
 tomli==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 antares-study-version~=1.0.18
 bcrypt~=5.0.0
-cffi~=1.15.1
+cffi~=2.1.0
 cryptography~=39.0.1
 paramiko~=3.4.1
 pycparser~=2.21

--- a/setup.py
+++ b/setup.py
@@ -101,5 +101,5 @@ setup(
     entry_points={
         "console_scripts": ["Antares_Launcher = antareslauncher.advanced_launch:main"],
     },
-    python_requires=">=3.10, <4",
+    python_requires=">=3.11, <4",
 )

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,9 @@ install_requires = [
 # Extra dependencies used for testing in "development" mode.
 # Use `pip install -e .[test]` to install.
 test_requires = [
-    "pytest ~= 7.2.1",
-    "pytest-cov ~= 4.0.0",
-    "pytest-xdist ~= 3.1.0",
+    "pytest ~= 9.1.1",
+    "pytest-cov ~= 7.1.0",
+    "pytest-xdist ~= 3.8.0",
 ]
 
 # Extra dependencies used for developing.
@@ -87,9 +87,10 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Environment :: Console",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,6 +9,7 @@ from antares.study.version import SolverMinorVersion
 
 from antareslauncher.data_repo.data_repo_tinydb import DataRepoTinydb
 from antareslauncher.display.display_terminal import DisplayTerminal
+from antareslauncher.enums import XpansionMode
 from antareslauncher.use_cases.create_list.study_list_composer import StudyListComposer, StudyListComposerParameters
 from tests.unit.assets import ASSETS_DIR
 
@@ -44,7 +45,7 @@ def study_list_composer_fixture(
             time_limit=42,
             n_cpu=24,
             log_dir=str(tmp_path.joinpath("LOGS")),
-            xpansion_mode="",
+            xpansion_mode=XpansionMode.NOT_XPANSION,
             output_dir=str(tmp_path.joinpath("FINISHED")),
             post_processing=False,
             antares_versions_on_remote_server=[

--- a/tests/unit/test_study_list_composer.py
+++ b/tests/unit/test_study_list_composer.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from antares.study.version import SolverMinorVersion
 
+from antareslauncher.enums import XpansionMode
 from antareslauncher.use_cases.create_list.study_list_composer import StudyListComposer, get_solver_version
 
 CONFIG_NOMINAL_VERSION = """\
@@ -72,7 +73,7 @@ class TestStudyListComposer:
         study_list_composer: StudyListComposer,
         xpansion_mode: str,
     ):
-        study_list_composer.xpansion_mode = xpansion_mode
+        study_list_composer.xpansion_mode = XpansionMode(xpansion_mode)
         study_list_composer.update_study_database()
         studies = study_list_composer.get_list_of_studies()
 

--- a/tests/unit/test_study_list_composer.py
+++ b/tests/unit/test_study_list_composer.py
@@ -68,11 +68,7 @@ class TestGetSolverVersion:
 
 class TestStudyListComposer:
     @pytest.mark.parametrize("xpansion_mode", ["r", "cpp", "", "trajectory"])
-    def test_update_study_database__xpansion_mode(
-        self,
-        study_list_composer: StudyListComposer,
-        xpansion_mode: str,
-    ):
+    def test_update_study_database__xpansion_mode(self, study_list_composer: StudyListComposer, xpansion_mode: str):
         study_list_composer.xpansion_mode = XpansionMode(xpansion_mode)
         study_list_composer.update_study_database()
         studies = study_list_composer.get_list_of_studies()

--- a/tests/unit/test_study_list_composer.py
+++ b/tests/unit/test_study_list_composer.py
@@ -80,11 +80,7 @@ class TestStudyListComposer:
         assert actual_names == expected_names
 
     @pytest.mark.parametrize("antares_version", [0, 850, 990])
-    def test_update_study_database__antares_version(
-        self,
-        study_list_composer: StudyListComposer,
-        antares_version: int,
-    ):
+    def test_update_study_database__antares_version(self, study_list_composer: StudyListComposer, antares_version: int):
         parsed_version = SolverMinorVersion.parse(antares_version)
         study_list_composer.antares_version = parsed_version
         study_list_composer.update_study_database()

--- a/tests/unit/test_study_list_composer.py
+++ b/tests/unit/test_study_list_composer.py
@@ -80,15 +80,11 @@ class TestStudyListComposer:
         # check the found studies
         actual_names = {s.name for s in studies}
         expected_names = {
-            "": {
-                "013 TS Generation - Solar power",
-                "024 Hurdle costs - 1",
-                "SMTA-case",
-            },
-            "r": {"SMTA-case"},
-            "cpp": {"SMTA-case"},
-            "trajectory": {"SMTA-case"},
-        }[study_list_composer.xpansion_mode or ""]
+            "013 TS Generation - Solar power",
+            "024 Hurdle costs - 1",
+            "SMTA-case",
+        }
+
         assert actual_names == expected_names
 
     @pytest.mark.parametrize("antares_version", [0, 850, 990])

--- a/tests/unit/test_study_list_composer.py
+++ b/tests/unit/test_study_list_composer.py
@@ -79,11 +79,7 @@ class TestStudyListComposer:
 
         # check the found studies
         actual_names = {s.name for s in studies}
-        expected_names = {
-            "013 TS Generation - Solar power",
-            "024 Hurdle costs - 1",
-            "SMTA-case",
-        }
+        expected_names = {"013 TS Generation - Solar power", "024 Hurdle costs - 1", "SMTA-case"}
 
         assert actual_names == expected_names
 


### PR DESCRIPTION
## The dev

We'll now allow users to run studies in XpansionMode even if the study does not have any Xpansion candidates.

This way, when having GEMS candidates we'll no longer have any issues.

Also, a new Enum `XpansionMode` is introduced in the code to avoid performing checks everywhere, we validate the mode right at the start.

## Note on AntaREST
Due to this, we'll have to use this Enum inside `AntaREST` otherwise it won't work anymore

## Python versions
Drop support of Python 3.10 in favor on Python 3.13 and 3.14